### PR TITLE
Changed version number in Podfile specs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ platform :ios, '8.0'
 
 pod 'ReactiveCocoa', '~> 2.4'
 pod 'Alamofire', :git => 'https://github.com/Alamofire/Alamofire', :tag => '1.1.3'
-pod 'RACAlamofire', :git => 'https://github.com/ararog/Alamofire-RACExtensions', :tag => '0.0.4'
+pod 'RACAlamofire', :git => 'https://github.com/ararog/Alamofire-RACExtensions', :tag => '0.0.6'
 ```
 
 ---


### PR DESCRIPTION
Hey!
The instructions say- `Alamofire-RACExtensions, :tag => '0.0.4'`, but the extension that provides `.rac_response()` is **not** available in that version. Version 0.0.6 works, though.
I spent a lot of time trying to figure this out. Please look into it.
Thanks a lot!
